### PR TITLE
Error handling advice

### DIFF
--- a/Zoo-DTO/src/main/java/dto/CommonErrorDTO.java
+++ b/Zoo-DTO/src/main/java/dto/CommonErrorDTO.java
@@ -1,0 +1,30 @@
+package dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommonErrorDTO {
+
+    /**
+     * код ошибки, который не будет меняться и на который можно завязать бизнес логику на клиенте
+     */
+    private String code;
+
+    /**
+     * сообщение об ошибке, которое может быть показано на клиенте
+     */
+    private String message;
+
+    /**
+     * время возникновения ошибки
+     */
+    private Instant timestamp;
+}

--- a/Zoo-orchestrator/src/main/java/com/nekromant/zoo/controller/advice/CommonExceptionHandler.java
+++ b/Zoo-orchestrator/src/main/java/com/nekromant/zoo/controller/advice/CommonExceptionHandler.java
@@ -1,0 +1,71 @@
+package com.nekromant.zoo.controller.advice;
+
+import com.nekromant.zoo.exception.AnimalRequestNotFoundException;
+import com.nekromant.zoo.exception.EmailSendFailedException;
+import com.nekromant.zoo.exception.InvalidRegistrationDataException;
+import com.nekromant.zoo.exception.SmsSendFailedException;
+import com.nekromant.zoo.exception.UserAlreadyExistException;
+import dto.CommonErrorDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.ServletWebRequest;
+
+import java.time.Instant;
+
+import static com.nekromant.zoo.controller.advice.ZooError.ZOO_INVALID_USER_DATA;
+import static com.nekromant.zoo.controller.advice.ZooError.ZOO_NOTIFICATION_SEND_FAILED;
+import static com.nekromant.zoo.controller.advice.ZooError.ZOO_NOT_REQUEST_NOT_FOUND;
+import static com.nekromant.zoo.controller.advice.ZooError.ZOO_UNEXPECTED;
+
+
+/**
+ * Единый интерфейс API обработки ошибок
+ */
+@ControllerAdvice
+@Slf4j
+public class CommonExceptionHandler {
+
+    @ExceptionHandler(Throwable.class)
+    public ResponseEntity<CommonErrorDTO> handleException(Exception e, ServletWebRequest request) {
+        log.error(e.getMessage(), e);
+        ZooError error = getError(e);
+        return ResponseEntity.status(error.httpStatus).body(createDto(error, e));
+    }
+
+    /**
+     * Маппинг исключения на ошибку
+     */
+    private ZooError getError(Exception exception) {
+        if (exception instanceof EmailSendFailedException) {
+            return ZOO_NOTIFICATION_SEND_FAILED;
+        }
+        if (exception instanceof SmsSendFailedException) {
+            return ZOO_NOTIFICATION_SEND_FAILED;
+        }
+        if (exception instanceof AnimalRequestNotFoundException) {
+            return ZOO_NOT_REQUEST_NOT_FOUND;
+        }
+        if (exception instanceof UserAlreadyExistException) {
+            return ZOO_INVALID_USER_DATA;
+        }
+        if (exception instanceof InvalidRegistrationDataException) {
+            return ZOO_INVALID_USER_DATA;
+        }
+        return ZOO_UNEXPECTED;
+    }
+
+    /**
+     * Создание дто ошибки
+     */
+    private CommonErrorDTO createDto(ZooError error, Exception ex) {
+        return CommonErrorDTO
+                .builder()
+                .code(error.name())
+                .message(ex.getMessage())
+                .timestamp(Instant.now())
+                .build();
+    }
+
+}

--- a/Zoo-orchestrator/src/main/java/com/nekromant/zoo/controller/advice/ZooError.java
+++ b/Zoo-orchestrator/src/main/java/com/nekromant/zoo/controller/advice/ZooError.java
@@ -1,0 +1,17 @@
+package com.nekromant.zoo.controller.advice;
+
+import org.springframework.http.HttpStatus;
+
+public enum ZooError {
+    //TODO Возвращать ошибки в едином формате там где это не сделано https://clck.ru/UgiYE
+    ZOO_NOTIFICATION_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR),
+    ZOO_NOT_REQUEST_NOT_FOUND(HttpStatus.BAD_REQUEST),
+    ZOO_UNEXPECTED(HttpStatus.INTERNAL_SERVER_ERROR),
+    ZOO_INVALID_USER_DATA(HttpStatus.BAD_REQUEST);
+
+    public HttpStatus httpStatus;
+
+    ZooError(HttpStatus httpStatus) {
+        this.httpStatus = httpStatus;
+    }
+}

--- a/Zoo-orchestrator/src/main/java/com/nekromant/zoo/exception/AnimalRequestNotFoundException.java
+++ b/Zoo-orchestrator/src/main/java/com/nekromant/zoo/exception/AnimalRequestNotFoundException.java
@@ -1,0 +1,7 @@
+package com.nekromant.zoo.exception;
+
+public class AnimalRequestNotFoundException extends RuntimeException{
+    public AnimalRequestNotFoundException(String animalRequestId) {
+        super("Не найдена заявка c id = " + animalRequestId);
+    }
+}

--- a/Zoo-orchestrator/src/main/java/com/nekromant/zoo/exception/EmailSendFailedException.java
+++ b/Zoo-orchestrator/src/main/java/com/nekromant/zoo/exception/EmailSendFailedException.java
@@ -1,0 +1,7 @@
+package com.nekromant.zoo.exception;
+
+public class EmailSendFailedException extends RuntimeException {
+    public EmailSendFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/Zoo-orchestrator/src/main/java/com/nekromant/zoo/exception/InvalidRegistrationDataException.java
+++ b/Zoo-orchestrator/src/main/java/com/nekromant/zoo/exception/InvalidRegistrationDataException.java
@@ -1,0 +1,7 @@
+package com.nekromant.zoo.exception;
+
+public class InvalidRegistrationDataException extends RuntimeException{
+    public InvalidRegistrationDataException (String message) {
+        super(message);
+    }
+}

--- a/Zoo-orchestrator/src/main/java/com/nekromant/zoo/exception/SmsSendFailedException.java
+++ b/Zoo-orchestrator/src/main/java/com/nekromant/zoo/exception/SmsSendFailedException.java
@@ -1,0 +1,7 @@
+package com.nekromant.zoo.exception;
+
+public class SmsSendFailedException extends RuntimeException{
+    public SmsSendFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/Zoo-orchestrator/src/main/java/com/nekromant/zoo/exception/UserAlreadyExistException.java
+++ b/Zoo-orchestrator/src/main/java/com/nekromant/zoo/exception/UserAlreadyExistException.java
@@ -1,0 +1,7 @@
+package com.nekromant.zoo.exception;
+
+public class UserAlreadyExistException extends RuntimeException{
+    public UserAlreadyExistException (String message) {
+        super(message);
+    }
+}

--- a/Zoo-orchestrator/src/main/java/com/nekromant/zoo/service/EmailService.java
+++ b/Zoo-orchestrator/src/main/java/com/nekromant/zoo/service/EmailService.java
@@ -1,22 +1,27 @@
 package com.nekromant.zoo.service;
 
+import com.nekromant.zoo.exception.EmailSendFailedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 @Service
-public class EmailService{
+public class EmailService {
 
     @Autowired
     private JavaMailSender mailSender;
 
-    public void sendEmail(String emailReceiver, String emailSubject, String emailText){
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(emailReceiver);
-        message.setSubject(emailSubject);
-        message.setText(emailText);
+    public void sendEmail(String emailReceiver, String emailSubject, String emailText) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(emailReceiver);
+            message.setSubject(emailSubject);
+            message.setText(emailText);
 
-        mailSender.send(message);
+            mailSender.send(message);
+        } catch (Throwable e) {
+            throw new EmailSendFailedException("Не удалось отправить сообщение на email " + emailReceiver, e);
+        }
     }
 }

--- a/Zoo-orchestrator/src/main/java/com/nekromant/zoo/service/UserService.java
+++ b/Zoo-orchestrator/src/main/java/com/nekromant/zoo/service/UserService.java
@@ -5,6 +5,9 @@ import com.nekromant.zoo.config.security.JwtProvider;
 import com.nekromant.zoo.dao.AnimalRequestDAO;
 import com.nekromant.zoo.dao.AuthorityDAO;
 import com.nekromant.zoo.dao.UserDAO;
+import com.nekromant.zoo.exception.AnimalRequestNotFoundException;
+import com.nekromant.zoo.exception.InvalidRegistrationDataException;
+import com.nekromant.zoo.exception.UserAlreadyExistException;
 import com.nekromant.zoo.mapper.UserMapper;
 import com.nekromant.zoo.model.AnimalRequest;
 import com.nekromant.zoo.model.Authority;
@@ -76,12 +79,10 @@ public class UserService {
                 insert(user);
                 log.info("Пользователь с email {} был успешно создан с формы регистрации!", email);
             } else {
-                log.warn("User {} already exists", email);
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "User exists!");
+                throw new UserAlreadyExistException("Пользователь с email " + email + " уже зарегистрирован");
             }
         } else {
-            log.error("Email = {} or password = {} is invalid! Register failed!", email, password);
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid data!");
+            throw new InvalidRegistrationDataException("Неверное имя пользователя или пароль");
         }
     }
 
@@ -97,7 +98,7 @@ public class UserService {
                 log.info("Пользователь с email {} был успешно создан при подтверждении заявки!", requestItem.getEmail());
             }
         } else {
-            log.error("Заявка (AnimalRequest) с id = {} не найдена! дальнейшая работа по проверке и созданию нового клиента невозможна!", requestId);
+            throw new AnimalRequestNotFoundException(requestId);
         }
     }
 
@@ -108,6 +109,7 @@ public class UserService {
             list.add(authority.get());
             return list;
         }
+        //TODO Избавиться от потенциального NPE https://clck.ru/UgjKW
         return null;
     }
 
@@ -117,6 +119,7 @@ public class UserService {
             userDetails = customUserDetailService.loadUserByUsername(email);
         } catch (UsernameNotFoundException e) {
             log.warn("User {} not found", email);
+            //TODO Возвращать ошибки в едином формате там где это не сделано https://clck.ru/UgiYE
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found");
         }
 
@@ -127,7 +130,7 @@ public class UserService {
 
             return jwtProvider.generateToken(email, authorities);
         }
-
+        //TODO Возвращать ошибки в едином формате там где это не сделано https://clck.ru/UgiYE
         throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not authenticated");
     }
 
@@ -155,6 +158,7 @@ public class UserService {
             log.info("Пароль для пользователя {} был успешно изменен!", email);
         } else {
             log.info("Пользователь {} не прошел валидацию данных при смене пароля!", email);
+            //TODO Возвращать ошибки в едином формате там где это не сделано https://clck.ru/UgiYE
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid data!");
         }
     }

--- a/Zoo-orchestrator/src/test/java/com/nekromant/zoo/service/UserServiceTest.java
+++ b/Zoo-orchestrator/src/test/java/com/nekromant/zoo/service/UserServiceTest.java
@@ -5,6 +5,8 @@ import com.nekromant.zoo.config.security.JwtProvider;
 import com.nekromant.zoo.dao.AnimalRequestDAO;
 import com.nekromant.zoo.dao.AuthorityDAO;
 import com.nekromant.zoo.dao.UserDAO;
+import com.nekromant.zoo.exception.InvalidRegistrationDataException;
+import com.nekromant.zoo.exception.UserAlreadyExistException;
 import com.nekromant.zoo.mapper.UserMapper;
 import com.nekromant.zoo.model.Authority;
 import com.nekromant.zoo.model.User;
@@ -88,28 +90,16 @@ public class UserServiceTest {
 
         Mockito.when(userDAO.findByEmail(Mockito.any())).thenReturn(new User());
 
-        Assert.assertThrows(ResponseStatusException.class, () -> {
-            userService.register(email, password);
-        });
+        Assert.assertThrows(UserAlreadyExistException.class, () -> userService.register(email, password));
     }
 
     @Test
     public void registerWhenAnyDataIsEmptyOrInvalid() {
-        Assert.assertThrows(ResponseStatusException.class, () -> {
-            userService.register("", "qwe");
-        });
-        Assert.assertThrows(ResponseStatusException.class, () -> {
-            userService.register("test", "qwe");
-        });
-        Assert.assertThrows(ResponseStatusException.class, () -> {
-            userService.register("test@", "qwe");
-        });
-        Assert.assertThrows(ResponseStatusException.class, () -> {
-            userService.register("test@gmail.com", "");
-        });
-        Assert.assertThrows(ResponseStatusException.class, () -> {
-            userService.register("", "");
-        });
+        Assert.assertThrows(InvalidRegistrationDataException.class, () -> userService.register("", "qwe"));
+        Assert.assertThrows(InvalidRegistrationDataException.class, () -> userService.register("test", "qwe"));
+        Assert.assertThrows(InvalidRegistrationDataException.class, () -> userService.register("test@", "qwe"));
+        Assert.assertThrows(InvalidRegistrationDataException.class, () -> userService.register("test@gmail.com", ""));
+        Assert.assertThrows(InvalidRegistrationDataException.class, () -> userService.register("", ""));
     }
 
     @Test
@@ -162,9 +152,7 @@ public class UserServiceTest {
 
         Mockito.when(customUserDetailService.loadUserByUsername(Mockito.any())).thenThrow(new UsernameNotFoundException(""));
 
-        Assert.assertThrows(ResponseStatusException.class, () -> {
-            userService.login(email, password);
-        });
+        Assert.assertThrows(ResponseStatusException.class, () -> userService.login(email, password));
     }
 
     @Test


### PR DESCRIPTION
Глобальная цель - улучшить обработку ошибок
Чтобы не плодить бесконечные ResponseStatusException и ResponseEntity<> можно создавать собственные исключения, которые будут перехвачены хендлером и превращены в сериализованную ошибку
Формат у всех ошибок будет общий, что позволит их адекватно в едином стиле обрабатывать при запросах с фронта и из других микросервисов
![image](https://user-images.githubusercontent.com/43813324/117378960-1c429e00-aedf-11eb-9225-e31a2c6f6d14.png)
Енам ZooError предназначен для логического объединения исключений по смыслу, в нем же указывается httpStatus ответа, который будет проставлен хендлером